### PR TITLE
fixing KB-9867: Learn hub – Recently added content > Show All result …

### DIFF
--- a/project/ws/app/src/lib/routes/search-v3/routes/learn-search/learn-search.component.ts
+++ b/project/ws/app/src/lib/routes/search-v3/routes/learn-search/learn-search.component.ts
@@ -211,6 +211,7 @@ export class LearnSearchComponent implements OnInit, OnChanges, OnDestroy {
       this.peopleSearchTotalCount = 0;
       this.communitiesSearchTotalCount = 0;
       this.searchRequestCourse.request.limit = this.initialPaginationSize;
+      this.searchRequestCourse.request.sort_by.createdOn = 'desc';
       await this.searchCourses();
       this.sideNavBarOpened = false
       this.searchContentLoader = false;


### PR DESCRIPTION
…page for recently added content shows sort by as ‘Recently added (Newest)’ but content result are sorted in alphabetical order