### PR TITLE
fixed APAR arrow filter and Overdue filter

### DIFF
--- a/src/app/component/cbp-plan-feed/cbp-plan-feed.component.html
+++ b/src/app/component/cbp-plan-feed/cbp-plan-feed.component.html
@@ -20,7 +20,7 @@
     </div>
     <div class="flex flex-wrap" *ngIf="filterApplied">
         <ng-container *ngFor="let item of filterObject | keyvalue">
-            <ng-container *ngIf="item?.key === 'isApar'">
+            <ng-container *ngIf="item?.key === 'isApar'&& item?.value">
                 <div class="tag-wrap flex margin-right-xs margin-bottom-xs">
                     <p>{{'cbpPlanStats.apar' | translate}}</p>
                     <mat-icon aria-hidden="true" (click)="closeFilter(item.value,item.key)"

--- a/src/app/component/upcoming-timeline/upcoming-timeline.component.ts
+++ b/src/app/component/upcoming-timeline/upcoming-timeline.component.ts
@@ -71,7 +71,7 @@ export class UpcomingTimelineComponent implements OnInit {
       competencySubTheme: [],
       providers: [],
     }
-    let finalFilterData: any = event === 'apar' ? apar : event === 'overDue' ? overDue : upcomingData
+    let finalFilterData: any = event === 'apar' ? apar : event === 'overdue' ? overDue : upcomingData
     this.filterValueEmit.emit(finalFilterData)
   }
   scroll(el: any) {


### PR DESCRIPTION
in My learner portal on my iGOT, where clicking the “>” arrow on the APAR instead of the APAR filter. The filter mapping has been corrected so that only courses marked as isApar=true are displayed.

also fixed where clicking the “>” arrow on the overdue, course card incorrectly applied the Overdue filter are fixed