### PR TITLE
Kb 12773 cb portal mobile view settings menu close

### DIFF
--- a/library/ws-widget/collection/src/lib/card-hubs-list/card-hubs-list.component.scss
+++ b/library/ws-widget/collection/src/lib/card-hubs-list/card-hubs-list.component.scss
@@ -296,6 +296,56 @@ mat-grid-list {
       line-height: normal;
     }
   }
+.explore-more {
+  min-width: 130px !important;
+  border-right: none;
+  padding-right: 0;
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+::ng-deep .explore-content-action {
+  height: auto !important;
+  line-height: normal !important;
+  padding: 0 !important;
+  border: none !important;
+  background: transparent !important;
+  box-shadow: none !important;
+
+  div.flex.items-center {
+    justify-content: center;
+    flex-direction: column;
+  }
+
+  mat-icon {
+    margin-right: 0 !important;
+    margin-bottom: 0px;
+    padding: 0 !important;
+    width: 24px;
+    height: 24px;
+    font-size: 24px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .explore-content-text {
+    max-width: none !important;
+    margin-top: 0px;
+
+    span {
+      white-space: nowrap;
+      overflow-wrap: break-word;
+      line-height: normal;
+    }
+
+    .arrow-chevron {
+      display: none;
+    }
+  }
+}
 }
 
 @media (max-width : 768px) {    

--- a/project/ws/app/src/lib/routes/profile/profile.component.html
+++ b/project/ws/app/src/lib/routes/profile/profile.component.html
@@ -9,6 +9,11 @@
   <mat-sidenav [mode]="mode$ | async" [(opened)]="sideNavBarOpened" class="border-0 "
     [ngClass]="{'margin-top-48': currentRoute === 'home'}">
     <div class="contain">
+      <div *ngIf="screenSizeIsLtMedium">
+        <button type="button" mat-icon-button (click)="sideNavBarOpened = false">
+          <mat-icon>keyboard_backspace</mat-icon>
+        </button>
+      </div>
       <div class="flex-1" style="position: relative;">
         <div #stickyMenu [class.sticky]="sticky">
           <ws-app-left-menu [tabsData]="tabsData" class="flex flex-1"></ws-app-left-menu>

--- a/project/ws/app/src/lib/routes/profile/profile.component.ts
+++ b/project/ws/app/src/lib/routes/profile/profile.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core'
 import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog'
-import { ActivatedRoute, Router } from '@angular/router'
+import { ActivatedRoute, Router, NavigationStart, Event } from '@angular/router'
 import { ConfigurationsService, LogoutComponent, NsPage, ValueService } from '@sunbird-cb/utils-v2'
 import { Subscription } from 'rxjs'
 import { map } from 'rxjs/operators'
@@ -15,6 +15,7 @@ import _ from 'lodash'
 export class ProfileComponent implements OnInit, OnDestroy {
   tabName = ''
   private defaultSideNavBarOpenedSubscription: Subscription | null = null
+  private routerSubscription: Subscription | null = null
   isLtMedium$ = this.valueSvc.isLtMedium$
   mode$ = this.isLtMedium$.pipe(map((isMedium: boolean) => (isMedium ? 'over' : 'side')))
   screenSizeIsLtMedium = false
@@ -59,6 +60,14 @@ export class ProfileComponent implements OnInit, OnDestroy {
     this.defaultSideNavBarOpenedSubscription = this.isLtMedium$.subscribe((isLtMedium: boolean) => {
       this.screenSizeIsLtMedium = isLtMedium
     })
+
+    this.routerSubscription = this.router.events.subscribe((event: Event) => {
+      if (event instanceof NavigationStart) {
+        if (this.screenSizeIsLtMedium) {
+          this.sideNavBarOpened = false
+        }
+      }
+    })
   }
   tabUpdate(tab: string) {
     this.tabName = tab
@@ -71,6 +80,9 @@ export class ProfileComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     if (this.defaultSideNavBarOpenedSubscription) {
       this.defaultSideNavBarOpenedSubscription.unsubscribe()
+    }
+    if (this.routerSubscription) {
+      this.routerSubscription.unsubscribe()
     }
   }
   logout() {


### PR DESCRIPTION
Fixed an issue in the Learner Portal where the Settings menu did not close after selecting an option in mobile view. The menu now closes correctly on selection, restoring expected user behavior.